### PR TITLE
Set API routes to use edge runtime

### DIFF
--- a/app/api/members/[id]/route.ts
+++ b/app/api/members/[id]/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getMemberService, updateMemberService, deleteMemberService } from "@/lib/services/members-service"
 
+export const runtime = 'edge'
+
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const member = await getMemberService(params.id, 1)

--- a/app/api/members/route.ts
+++ b/app/api/members/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getMembersService, createMemberService } from "@/lib/services/members-service"
 
+export const runtime = 'edge'
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)

--- a/app/api/newcomers/route.ts
+++ b/app/api/newcomers/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getNewcomersService, createNewcomerService } from "@/lib/services/newcomers-service"
 
+export const runtime = 'edge'
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)

--- a/app/api/prayer-requests/route.ts
+++ b/app/api/prayer-requests/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getPrayerRequestsService, createPrayerRequestService } from "@/lib/services/prayer-requests-service"
 
+export const runtime = 'edge'
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)


### PR DESCRIPTION
Added 'export const runtime = "edge"' to members, newcomers, and prayer-requests API route handlers to enable edge runtime execution for improved performance and scalability.