### PR TITLE
Refactor API service calls to use object parameter

### DIFF
--- a/app/api/members/route.ts
+++ b/app/api/members/route.ts
@@ -8,7 +8,9 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const churchId = searchParams.get("churchId") || "1"
 
-    const members = await getMembersService(Number.parseInt(churchId))
+    const members = await getMembersService({
+      churchId: Number.parseInt(churchId)
+    })
     return NextResponse.json({ success: true, data: members })
   } catch (error) {
     console.error("Error fetching members:", error)

--- a/app/api/newcomers/route.ts
+++ b/app/api/newcomers/route.ts
@@ -8,7 +8,9 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const churchId = searchParams.get("churchId") || "1"
 
-    const newcomers = await getNewcomersService(Number.parseInt(churchId))
+    const newcomers = await getNewcomersService({
+      churchId: Number.parseInt(churchId)
+    })
     return NextResponse.json({ success: true, data: newcomers })
   } catch (error) {
     console.error("Error fetching newcomers:", error)

--- a/app/api/prayer-requests/route.ts
+++ b/app/api/prayer-requests/route.ts
@@ -8,7 +8,9 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const churchId = searchParams.get("churchId") || "1"
 
-    const requests = await getPrayerRequestsService(Number.parseInt(churchId))
+    const requests = await getPrayerRequestsService({
+      churchId: Number.parseInt(churchId)
+    })
     return NextResponse.json({ success: true, data: requests })
   } catch (error) {
     console.error("Error fetching prayer requests:", error)


### PR DESCRIPTION
Updated the GET handlers in members, newcomers, and prayer-requests API routes to pass an object with churchId to their respective service functions instead of a positional argument. This change improves clarity and consistency in service function calls.