### PR TITLE
Add role-based access to prayer requests management

### DIFF
--- a/components/dashboard/weekly-report-form.tsx
+++ b/components/dashboard/weekly-report-form.tsx
@@ -98,7 +98,7 @@ export function WeeklyReportForm({ onSuccess }: WeeklyReportFormProps) {
                 new_members: parseInt(data.new_members),
             }
 
-            await apiClient.createWeeklyReport(token, reportData)
+            await apiClient.createWeeklyReport(reportData, token)
             setSuccess(true)
             reset()
             if (onSuccess) onSuccess()


### PR DESCRIPTION
Restricts certain actions and UI elements in the prayer requests management component to users with 'super_admin' or 'church_pastor' roles. Also fixes user name formatting when submitting new requests. Updates weekly report API call to match new parameter order.