### PR TITLE
Fix missing closing div in weekly reports management

### DIFF
--- a/components/dashboard/weekly-reports-management.tsx
+++ b/components/dashboard/weekly-reports-management.tsx
@@ -451,6 +451,7 @@ export function WeeklyReportsManagement() {
                             </div>
                           </DialogContent>
                         </Dialog>
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))


### PR DESCRIPTION
Added a missing closing div tag inside the WeeklyReportsManagement component to ensure proper HTML structure and prevent rendering issues.