### PR TITLE
Fix PreachingSchedulesManagement import style

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { EventsManagement } from "@/components/dashboard/events-management";
 import { PrayerRequestsManagement } from "@/components/dashboard/prayer-requests-management";
 import { MinistriesManagement } from "@/components/dashboard/ministries-management";
 import { ChurchesManagement } from "@/components/dashboard/churches-management";
-import PreachingSchedulesManagement from "@/components/dashboard/preaching-schedules-management";
+import { PreachingSchedulesManagement } from "@/components/dashboard/preaching-schedules-management";
 import { WeeklyReportsManagement } from "@/components/dashboard/weekly-reports-management";
 import { EmailConfigManagement } from "@/components/dashboard/email-config-management";
 

--- a/app/dashboard/super-admin/page.tsx
+++ b/app/dashboard/super-admin/page.tsx
@@ -15,7 +15,7 @@ import { PhoneInput } from "@/components/ui/phone-input"
 import { useChurch } from "@/components/providers/church-context"
 import { WeeklyReportsManagement } from "@/components/dashboard/weekly-reports-management"
 import { ChurchesManagement } from "@/components/dashboard/churches-management"
-import PreachingSchedulesManagement from "@/components/dashboard/preaching-schedules-management"
+import { PreachingSchedulesManagement } from "@/components/dashboard/preaching-schedules-management";
 import MembersManagement from "@/components/dashboard/members-management"
 import { QRAttendanceManagement } from "@/components/dashboard/qr-attendance-management"
 

--- a/app/dashboard/tab-components.tsx
+++ b/app/dashboard/tab-components.tsx
@@ -7,7 +7,7 @@ import { EventsManagement } from "@/components/dashboard/events-management";
 import { PrayerRequestsManagement } from "@/components/dashboard/prayer-requests-management";
 import { MinistriesManagement } from "@/components/dashboard/ministries-management";
 import { ChurchesManagement } from "@/components/dashboard/churches-management";
-import PreachingSchedulesManagement from "@/components/dashboard/preaching-schedules-management";
+import { PreachingSchedulesManagement } from "@/components/dashboard/preaching-schedules-management";
 import { WeeklyReportsManagement } from "@/components/dashboard/weekly-reports-management";
 import { EmailConfigManagement } from "@/components/dashboard/email-config-management";
 


### PR DESCRIPTION
Updated imports of PreachingSchedulesManagement to use named import syntax for consistency and to match the component's export style.